### PR TITLE
Fix session cleanup bug and axios header config

### DIFF
--- a/backend/src/main/java/fr/zelytra/session/SessionManager.java
+++ b/backend/src/main/java/fr/zelytra/session/SessionManager.java
@@ -89,14 +89,20 @@ public class SessionManager {
      * @param player The player to remove from their session.
      */
     public void leaveSession(Player player) {
-        for (Fleet fleet : sessions.values()) {
-            fleet.getPlayers().remove(player);
-            SessionSocket.broadcastSessionUpdate(fleet.getSessionId());
-            Log.info("[" + fleet.getSessionId() + "] " + player.getUsername() + " Leave the session !");
+        var iterator = sessions.entrySet().iterator();
+        while (iterator.hasNext()) {
+            var entry = iterator.next();
+            Fleet fleet = entry.getValue();
+
+            boolean removed = fleet.getPlayers().remove(player);
+            if (removed) {
+                SessionSocket.broadcastSessionUpdate(fleet.getSessionId());
+                Log.info("[" + fleet.getSessionId() + "] " + player.getUsername() + " Leave the session !");
+            }
 
             // Clean empty session
             if (fleet.getPlayers().isEmpty()) {
-                sessions.remove(fleet.getSessionId());
+                iterator.remove();
                 Log.info("[" + fleet.getSessionId() + "] Has been disbanded");
             }
         }

--- a/frontend/src/objects/HTTPAxios.ts
+++ b/frontend/src/objects/HTTPAxios.ts
@@ -21,12 +21,18 @@ export class HTTPAxios {
             timeout: Infinity
         });
 
-        this.axios.interceptors.request.use(async config => {
-            config.headers.set(this.header)
-            return config;
-        }, error => {
-            return Promise.reject(error);
-        });
+        this.axios.interceptors.request.use(
+            async config => {
+                config.headers = {
+                    ...config.headers,
+                    ...this.header,
+                };
+                return config;
+            },
+            error => {
+                return Promise.reject(error);
+            }
+        );
 
     }
 


### PR DESCRIPTION
## Summary
- fix concurrent modification when removing player from session
- correctly merge headers in axios interceptor

## Testing
- `./mvnw -q test` *(fails: Could not find Maven)*
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e39bb8083289769783f2fc89786